### PR TITLE
Growthcraft 1.11 3

### DIFF
--- a/src/main/java/growthcraft/fishtrap/Reference.java
+++ b/src/main/java/growthcraft/fishtrap/Reference.java
@@ -3,7 +3,7 @@ package growthcraft.fishtrap;
 public class Reference {
     public static final String MODID = "growthcraft_fishtrap";
     public static final String NAME = "Growthcraft Fishtrap";
-    public static final String VERSION = "3.0.0-alpha";
+    public static final String VERSION = "3.0.0.1";
 
 	public static final String CLIENT_PROXY_CLASS = "growthcraft.fishtrap.proxy.ClientProxy";
 	public static final String SERVER_PROXY_CLASS = "growthcraft.fishtrap.proxy.CommonProxy";


### PR DESCRIPTION
New Features
- #3 Fishtrap is now craftable.
- #3 Split Entity Inventory into input and output.
- #8 Made Fishtrap aware of its surrounding blocks. We can no longer catch flying fish.

Fixes
- Discord Reported: fixed tooltip reference for Fishtrap.
- Discord Reported: fixed name reference for Light Blue Crowbar.
- #3 Fixed Fishtrap Hooper access. Sides are now inventory aware.
